### PR TITLE
fix: module declares

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,13 @@ export interface YLRUOptions {
   maxAge?: number;
 }
 
-export default class YLRU {
+declare class YLRU {
   constructor(max: number)
   get: <T = any>(key: any, options?: YLRUOptions) => T | undefined;
   set: <T = any>(key: any, value: T, options?: YLRUOptions) => void;
   keys: () => any[];
+}
+
+declare module 'ylru' {
+  export = YLRU;
 }


### PR DESCRIPTION
* There is no `export default` in origin code of ylru
* Use `export default  class YLRU ` will break `import * as LRU from 'ylru'`  